### PR TITLE
fix: INFR-4934 remove lifecycle block to unblock lambda releases

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -143,10 +143,6 @@ resource "aws_lambda_function" "this" {
     var.function_tags
   )
 
-  lifecycle {
-    ignore_changes = [image_uri]
-  }
-
   depends_on = [
     # null_resource.archive,
     # aws_s3_object.lambda_package,


### PR DESCRIPTION
## ℹ️ Overview

- Last release introduced the lifecycle block which is now blocking lambda releases; this is a roll forward to remove the block but keep the other updates introduced in the last release

## 🧪 Test Instructions

Here are the steps to verify the change works as expected and does not introduce regressions.

1. 
2. 
3. 

### Test Results

Here are the testing results with relevant screenshots, screen recordings, query outputs, etc.

## 📝 Authoring Guidelines

> [!TIP]
> Read through our full [PR Guidelines](https://www.notion.so/alloy/PR-Guidelines-22c05351a8d280c898d8c8a0b486d96d#23205351a8d28009b535d9218306a268).

As the author, I verify that I have:

- [ ] Followed the test instructions and updated the test results.
- [ ] Added/updated unit tests as applicable.
- [ ] Added/updated documentation as applicable.

## 💬 Reviewer Guidelines

> [!TIP]
> Read through our full [PR Guidelines](https://www.notion.so/alloy/PR-Guidelines-22c05351a8d280c898d8c8a0b486d96d#24705351a8d2802998f6e5e0612bfd4c).

Reviewers are responsible for:

- Reading the full PR description.
- Evaluating all code changes, including edge cases and regressions.
- Testing the change (locally or in ephemeral environments, if applicable).
- Leaving thoughtful, actionable feedback.
- Clearly signaling approval or requesting changes.

## 🚨 Risks

There may be possible side effects or negative impacts from these changes:

- [ ] Authentication and/or authorization
- [ ] Data privacy
- [ ] Networking
- [ ] Major configuration
- [ ] Other core setup (please clarify below)